### PR TITLE
install: Remove auto-start of services

### DIFF
--- a/pkg/couldinho-base.install
+++ b/pkg/couldinho-base.install
@@ -32,9 +32,9 @@ post_upgrade() {
     cp /etc/conf.d/couldinho-snapper /etc/conf.d/snapper
 
     # Start services
-    systemctl enable --now NetworkManager.service
-    systemctl enable --now snapper-cleanup.timer
-    systemctl enable --now strongswan.service
-    systemctl enable --now usbguard.service
-    systemctl enable --now usbguard-dbus.service
+    systemctl enable NetworkManager.service
+    systemctl enable snapper-cleanup.timer
+    systemctl enable strongswan.service
+    systemctl enable usbguard.service
+    systemctl enable usbguard-dbus.service
 }


### PR DESCRIPTION
Running the install script is generally done through chroot, so some services fail on start. They will remain enabled but only start when the system restarts.